### PR TITLE
Bugfix UC10

### DIFF
--- a/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
@@ -95,29 +95,41 @@ namespace Grocery.App.ViewModels
         }
 
         [RelayCommand]
-        public void IncreaseAmount(int productId)
+        public void IncreaseAmount(GroceryListItem item)
         {
-            GroceryListItem? item = MyGroceryListItems.FirstOrDefault(x => x.ProductId == productId);
             if (item == null) return;
-            if (item.Amount >= item.Product.Stock) return;
+            if (item.Product.Stock <= 0) return;
+
             item.Amount++;
-            _groceryListItemsService.Update(item);
             item.Product.Stock--;
+
+            _groceryListItemsService.Update(item);
             _productService.Update(item.Product);
-            OnGroceryListChanged(GroceryList);
         }
 
         [RelayCommand]
-        public void DecreaseAmount(int productId)
+        public void DecreaseAmount(GroceryListItem item)
         {
-            GroceryListItem? item = MyGroceryListItems.FirstOrDefault(x => x.ProductId == productId);
             if (item == null) return;
-            if (item.Amount <= 0) return;
-            item.Amount--;
-            _groceryListItemsService.Update(item);
-            item.Product.Stock++;
-            _productService.Update(item.Product);
-            OnGroceryListChanged(GroceryList);
+
+            if (item.Amount <= 1)
+            {
+                // eerst stock terugzetten
+                item.Product.Stock++;
+                _productService.Update(item.Product);
+
+                // dan echt verwijderen
+                _groceryListItemsService.Delete(item);
+                MyGroceryListItems.Remove(item);
+            }
+            else
+            {
+                item.Amount--;
+                item.Product.Stock++;
+                _groceryListItemsService.Update(item);
+                _productService.Update(item.Product);
+            }
+
         }
     }
 }

--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -5,7 +5,8 @@
              xmlns:vm="clr-namespace:Grocery.App.ViewModels"
              x:Class="Grocery.App.Views.GroceryListItemsView"
              x:DataType="vm:GroceryListItemsViewModel"
-             Title="GroceryListItemsView">
+             Title="GroceryListItemsView"
+             x:Name="ThisPage">
 
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Wijzig kleur" Command="{Binding ChangeColorCommand}" IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
@@ -40,12 +41,22 @@
                             </Grid.ColumnDefinitions>
                             <Label Grid.Column="0" Text="{Binding Product.Name}" VerticalOptions="Center"/>
                             <Label Grid.Column="1" Text="{Binding Amount}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"/>
-                            <Grid Grid.Column="2">
-                                <Image Source="plus.png" WidthRequest="15" HeightRequest="15"/>
-                            </Grid>
-                            <Grid Grid.Column="3">
-                                <Image Source="min.png" WidthRequest="15" HeightRequest="15"/>
-                            </Grid>
+                            
+                            <Image Grid.Column="2" Source="plus.png" WidthRequest="15" HeightRequest="15" HorizontalOptions="Center" VerticalOptions="Center">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer 
+                                        Command="{Binding Source={x:Reference ThisPage}, Path=BindingContext.IncreaseAmountCommand}" 
+                                        CommandParameter="{Binding .}" />
+                                </Image.GestureRecognizers>
+                            </Image>
+
+                            <Image Grid.Column="3" Source="min.png" WidthRequest="15" HeightRequest="15" HorizontalOptions="Center" VerticalOptions="Center">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer 
+                                        Command="{Binding Source={x:Reference ThisPage}, Path=BindingContext.DecreaseAmountCommand}" 
+                                        CommandParameter="{Binding .}" />
+                                </Image.GestureRecognizers>
+                            </Image>
                         </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Grocery.Core.Data/Repositories/GroceryListItemsRepository.cs
+++ b/Grocery.Core.Data/Repositories/GroceryListItemsRepository.cs
@@ -5,7 +5,7 @@ namespace Grocery.Core.Data.Repositories
 {
     public class GroceryListItemsRepository : IGroceryListItemsRepository
     {
-        private readonly List<GroceryListItem> groceryListItems;
+        private readonly List<GroceryListItem> groceryListItems = new();
 
         public GroceryListItemsRepository()
         {
@@ -36,9 +36,16 @@ namespace Grocery.Core.Data.Repositories
             return Get(item.Id);
         }
 
+
         public GroceryListItem? Delete(GroceryListItem item)
         {
-            throw new NotImplementedException();
+            var existing = groceryListItems.FirstOrDefault(x => x.Id == item.Id);
+            if (existing != null)
+            {
+                groceryListItems.Remove(existing);
+                return existing;
+            }
+            return null;
         }
 
         public GroceryListItem? Get(int id)

--- a/Grocery.Core/Models/GroceryListItem.cs
+++ b/Grocery.Core/Models/GroceryListItem.cs
@@ -1,17 +1,27 @@
-﻿namespace Grocery.Core.Models
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Grocery.Core.Models
 {
-    public class GroceryListItem : Model
+    public partial class GroceryListItem : ObservableObject
     {
         public int GroceryListId { get; set; }
         public int ProductId { get; set; }
-        public int Amount { get; set; }
-        public GroceryListItem(int id, int groceryListId, int productId, int amount) : base(id, "")
+
+        [ObservableProperty]
+        private int amount;
+
+        [ObservableProperty]
+        private Product product;
+
+        public GroceryListItem(int id, int groceryListId, int productId, int amount) 
         {
+            Id = id;
             GroceryListId = groceryListId;
             ProductId = productId;
             Amount = amount;
+            Product = new Product(0, "None", 0);
         }
 
-        public Product Product { get; set; } = new(0, "None", 0);
+        public int Id { get; set; }  
     }
 }

--- a/Grocery.Core/Services/GroceryListItemsService.cs
+++ b/Grocery.Core/Services/GroceryListItemsService.cs
@@ -36,7 +36,7 @@ namespace Grocery.Core.Services
 
         public GroceryListItem? Delete(GroceryListItem item)
         {
-            throw new NotImplementedException();
+            return _groceriesRepository.Delete(item);
         }
 
         public GroceryListItem? Get(int id)
@@ -58,7 +58,11 @@ namespace Grocery.Core.Services
         {
             foreach (GroceryListItem g in groceryListItems)
             {
-                g.Product = _productRepository.Get(g.ProductId) ?? new(0, "", 0);
+                var product = _productRepository.Get(g.ProductId);
+
+                g.Product = product != null
+                    ? new Product(product.Id, product.Name, product.Stock)  // clone
+                    : new Product(0, "Onbekend", 0);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Deze UC toont de klanten die een bepaald product hebben gekocht:
 - In Client Repo koppel je de rol Role.Admin aan user3 (= admin).
 - In BoughtProductsService werk je de Get(productid) functie uit zodat alle Clients die product met productid hebben gekocht met client, boodschappenlijst en product in de lijst staan die wordt geretourneerd.  
 - In BoughtProductsView moet de naam van de Client ewn de naam van de Boodschappenlijst worden getoond in de CollectionView.  
-- In BoughtProductsViewModel de OnSelectedProductChanged uitwerken zodat bij een ander product de lijst correct wordt gevuld.  
+- In BoughtProductsViewModel de   OnSelectedProductChanged uitwerken zodat bij een ander product de lijst correct wordt gevuld.  
 - In GroceryListViewModel maak je de methode ShowBoughtProducts(). Als de Client de rol admin heeft dan navigeer je naar BoughtProductsView. Anders doe je niets.  
 - In GroceryListView voeg je een ToolbarItem toe met als binding Client.Name en als Command ShowBoughtProducts.  
 


### PR DESCRIPTION
**Bugfix product referenties**
- FillService aangepast → Product wordt nu gekloond per GroceryListItem zodat plus/min niet meerdere items tegelijk beïnvloeden.

**ViewModel verbeteringen**
- IncreaseAmount en DecreaseAmount werken nu direct op het GroceryListItem.
- DecreaseAmount uitgebreid → als Amount == 1 en je klikt -, dan wordt het item verwijderd en voorraad teruggezet.
- OnGroceryListChanged niet meer onnodig gebruikt bij elke wijziging → UI updates via ObservableCollection en property changes.

**Repository Delete geïmplementeerd**
- Delete methode in GroceryListItemsRepository toegevoegd zodat items echt uit de repo verwijderd worden.
- Service Delete roept netjes repo aan.

**XAML verbeterd (UC10)**
- Plus/min knoppen werken nu via TapGestureRecognizer met CommandParameter="{Binding .}".
- Bindingen aangepast om correcte GroceryListItem door te geven.

**Crash fix**

- App crasht niet meer bij DecreaseAmount → 0 → verwijderen.